### PR TITLE
Basic Dockerfile for current version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx:1.25.2-alpine3.18
+
+WORKDIR /usr/share/nginx/html
+
+RUN wget -q -O honey.zip https://github.com/dani3l0/honey/releases/download/v2.1.1/honey-v2.1.1-stable.zip && unzip -q -o honey.zip && rm honey.zip
+
+EXPOSE 80
+
+HEALTHCHECK CMD wget -nv --spider --tries=1 http://127.0.0.1:80


### PR DESCRIPTION
This is a very basic Dockerfile to use to produce a image running a simple nginx webserver with the v2.1.1-stable release downloaded and extracted into its webserver root, nothing more.

It should work with Github Actions to automatically build and push it to the Github repo and the Docker Hub repo, or wherever else.

Ideally there would be a URL to always grab the latest release for the build, instead of a fixed link to a specific version number. I believe Github offers some way to do this as fixed URLs but i honestly couldnt figure it out myself.

For example `https://api.github.com/repos/dani3l0/honey/zipball` works to get the latest zip as download regardless of version number, but the problem then is that inside the zip the files are in a subfolder with `honey-commit-hash` or something. And that causes trouble when trying to automatically extract it to the actual webserver share in the Docker image. Of course that is doable tho, just not very elegant. A proper direct download URL would be ideal imo.

Oh and i am no Github expert or let alone a actual developer of anything, this is i think my first PR ever, please let me know if i have done anything wrong or against etiquette.